### PR TITLE
Update ttt_radio.sp remove red Color for Traitor

### DIFF
--- a/addons/sourcemod/scripting/ttt/ttt_radio.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_radio.sp
@@ -75,7 +75,7 @@ public Action Command_Radio(int client, int args)
 	}
 	else if (role == TTT_TEAM_TRAITOR)
 	{
-		Format(sColor, sizeof(sColor), "darkred");
+		Format(sColor, sizeof(sColor), "green");
 	}
 	else if (role == TTT_TEAM_DETECTIVE)
 	{

--- a/addons/sourcemod/scripting/ttt/ttt_radio.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_radio.sp
@@ -69,11 +69,7 @@ public Action Command_Radio(int client, int args)
 	char sColor[16];
 	int role = TTT_GetClientRole(client);
 	
-	if (role == TTT_TEAM_INNOCENT)
-	{
-		Format(sColor, sizeof(sColor), "green");
-	}
-	else if (role == TTT_TEAM_TRAITOR)
+	if (role == TTT_TEAM_INNOCENT || TTT_TEAM_TRAITOR)
 	{
 		Format(sColor, sizeof(sColor), "green");
 	}


### PR DESCRIPTION
Change Code to remove red color on Traitors or else traitors who use the radio will give away that they are a traitor.