### PR TITLE
Feature to avoid losing karma (Issue #179)

### DIFF
--- a/addons/sourcemod/scripting/ttt/core/config.sp
+++ b/addons/sourcemod/scripting/ttt/core/config.sp
@@ -124,7 +124,7 @@ void SetupConfig()
 	g_cDamageKarmaDD = AutoExecConfig_CreateConVar("ttt_damage_karma_attacker_detective_victim_detective_subtract", "1", "The amount of karma a detective will lose for damage a detective.");
 	g_cDoublePushInno = AutoExecConfig_CreateConVar("ttt_double_push_innocents", "1", "Push innocents (from last round) two times into players array? This should increase the chance to get traitor in the new round.", _, true, 0.0, true, 1.0);
 	g_cDoublePushDete = AutoExecConfig_CreateConVar("ttt_double_push_detective", "1", "Push detective (from last round) two times into players array? This should increase the chance to get traitor in the new round.", _, true, 0.0, true, 1.0);
-	g_cKarmaDecreaseWhenKillPlayerWhoHurt =  = AutoExecConfig_CreateConVar("ttt_karma_decrease_kill_player_who_hurted", "1", "Decrease Karma when you kill a player who hurted you?.", _, true, 0.0, true, 1.0);
+	g_cKarmaDecreaseWhenKillPlayerWhoHurt = AutoExecConfig_CreateConVar("ttt_karma_decrease_kill_player_who_hurted", "1", "Decrease Karma when you kill a player who hurted you?.", _, true, 0.0, true, 1.0);
 	
 	g_cpluginTag.AddChangeHook(OnConVarChanged);
 	g_ckickImmunity.AddChangeHook(OnConVarChanged);

--- a/addons/sourcemod/scripting/ttt/core/config.sp
+++ b/addons/sourcemod/scripting/ttt/core/config.sp
@@ -124,6 +124,7 @@ void SetupConfig()
 	g_cDamageKarmaDD = AutoExecConfig_CreateConVar("ttt_damage_karma_attacker_detective_victim_detective_subtract", "1", "The amount of karma a detective will lose for damage a detective.");
 	g_cDoublePushInno = AutoExecConfig_CreateConVar("ttt_double_push_innocents", "1", "Push innocents (from last round) two times into players array? This should increase the chance to get traitor in the new round.", _, true, 0.0, true, 1.0);
 	g_cDoublePushDete = AutoExecConfig_CreateConVar("ttt_double_push_detective", "1", "Push detective (from last round) two times into players array? This should increase the chance to get traitor in the new round.", _, true, 0.0, true, 1.0);
+	g_cKarmaDecreaseWhenKillPlayerWhoHurt =  = AutoExecConfig_CreateConVar("ttt_karma_decrease_kill_player_who_hurted", "1", "Decrease Karma when you kill a player who hurted you?.", _, true, 0.0, true, 1.0);
 	
 	g_cpluginTag.AddChangeHook(OnConVarChanged);
 	g_ckickImmunity.AddChangeHook(OnConVarChanged);

--- a/addons/sourcemod/scripting/ttt/core/globals.sp
+++ b/addons/sourcemod/scripting/ttt/core/globals.sp
@@ -56,7 +56,7 @@ bool g_bAvoidDetective[MAXPLAYERS + 1] =  { false, ... };
 
 int hurtedPlayer1[MAXPLAYERS + 1] =  { -1, ... };
 int hurtedPlayer2[MAXPLAYERS + 1] =  { -1, ... };
-bool renewHurt[MAXPLAYERS + 1] =  { false, ... };
+bool resetHurt[MAXPLAYERS + 1] =  { false, ... };
 
 Handle g_hRoundTimer = null;
 

--- a/addons/sourcemod/scripting/ttt/core/globals.sp
+++ b/addons/sourcemod/scripting/ttt/core/globals.sp
@@ -54,9 +54,9 @@ bool g_bCheckPlayers = false;
 int g_iLastRole[MAXPLAYERS + 1] =  {TTT_TEAM_UNASSIGNED, ...};
 bool g_bAvoidDetective[MAXPLAYERS + 1] =  { false, ... };
 
-int hurtedPlayer1[MAXPLAYERS + 1] =  { -1, ... };
-int hurtedPlayer2[MAXPLAYERS + 1] =  { -1, ... };
-bool resetHurt[MAXPLAYERS + 1] =  { false, ... };
+int g_bHurtedPlayer1[MAXPLAYERS + 1] =  { -1, ... };
+int g_bHurtedPlayer2[MAXPLAYERS + 1] =  { -1, ... };
+bool g_bResetHurt[MAXPLAYERS + 1] =  { false, ... };
 
 Handle g_hRoundTimer = null;
 

--- a/addons/sourcemod/scripting/ttt/core/globals.sp
+++ b/addons/sourcemod/scripting/ttt/core/globals.sp
@@ -54,6 +54,10 @@ bool g_bCheckPlayers = false;
 int g_iLastRole[MAXPLAYERS + 1] =  {TTT_TEAM_UNASSIGNED, ...};
 bool g_bAvoidDetective[MAXPLAYERS + 1] =  { false, ... };
 
+int hurtedPlayer1[MAXPLAYERS + 1] =  { -1, ... };
+int hurtedPlayer2[MAXPLAYERS + 1] =  { -1, ... };
+bool renewHurt[MAXPLAYERS + 1] =  { false, ... };
+
 Handle g_hRoundTimer = null;
 
 bool g_bInactive = false;
@@ -274,6 +278,7 @@ ConVar g_cDamageKarmaDT = null;
 ConVar g_cDamageKarmaDD = null;
 ConVar g_cDoublePushInno = null;
 ConVar g_cDoublePushDete = null;
+ConVar g_cKarmaDecreaseWhenKillPlayerWhoHurt = null;
 
 Handle g_hRules = null;
 bool g_bRules[MAXPLAYERS + 1] =  { false, ... };

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -594,9 +594,9 @@ public Action Event_RoundStartPre(Event event, const char[] name, bool dontBroad
 		g_iDetectiveKills[i] = 0;
 		g_bImmuneRDMManager[i] = false;
 		
-		hurtedPlayer1[i] = -1;
-		hurtedPlayer2[i] = -1;
-		resetHurt[i] = false;
+		g_bHurtedPlayer1[i] = -1;
+		g_bHurtedPlayer2[i] = -1;
+		g_bResetHurt[i] = false;
 		
 		DispatchKeyValue(i, "targetname", "UNASSIGNED");
 		CS_SetClientClanTag(i, " ");
@@ -2629,9 +2629,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		Format(iItem, sizeof(iItem), "-> [%N%s (Innocent) killed %N%s (Innocent) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
 		
-		if (hurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		if (g_bHurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
-		} else if (hurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		} else if (g_bHurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
 		} else {
 			subtractKarma(iAttacker, g_ckarmaII.IntValue, true);
@@ -2649,9 +2649,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		Format(iItem, sizeof(iItem), "-> [%N%s (Innocent) killed %N%s (Detective) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
 		
-		if (hurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		if (g_bHurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
-		} else if (hurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		} else if (g_bHurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
 		} else {
 			subtractKarma(iAttacker, g_ckarmaID.IntValue, true);
@@ -2669,9 +2669,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		Format(iItem, sizeof(iItem), "-> [%N%s (Traitor) killed %N%s (Traitor) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
 		
-		if (hurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		if (g_bHurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt traitor");
-		} else if (hurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		} else if (g_bHurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt traitor");
 		} else {
 			subtractKarma(iAttacker, g_ckarmaTT.IntValue, true);
@@ -2689,9 +2689,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		Format(iItem, sizeof(iItem), "-> [%N%s (Detective) killed %N%s (Innocent) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
 		
-		if (hurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		if (g_bHurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
-		} else if (hurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		} else if (g_bHurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
 		} else {
 			subtractKarma(iAttacker, g_ckarmaDI.IntValue, true);
@@ -2709,9 +2709,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		Format(iItem, sizeof(iItem), "-> [%N%s (Detective) killed %N%s (Detective) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
 		
-		if (hurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		if (g_bHurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
-		} else if (hurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		} else if (g_bHurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
 		} else {
 			subtractKarma(iAttacker, g_ckarmaDD.IntValue, true);
@@ -2756,16 +2756,16 @@ public Action Event_PlayerHurt(Event event, const char[] name, bool dontBroadcas
 	   (g_iRole[iAttacker] == TTT_TEAM_DETECTIVE && g_iRole[client] == TTT_TEAM_INNOCENT) ||
 	   (g_iRole[iAttacker] == TTT_TEAM_DETECTIVE && g_iRole[client] == TTT_TEAM_DETECTIVE))
 	{
-		if (hurtedPlayer1[iAttacker] == -1 && iAttacker != hurtedPlayer1[client]) {
-			hurtedPlayer1[iAttacker] = client;
-		} else if (hurtedPlayer2[iAttacker] == -1 && iAttacker != hurtedPlayer2[client] && iAttacker != hurtedPlayer1[client]) {
-			hurtedPlayer2[iAttacker] = client;
-		} else if (iAttacker != hurtedPlayer1[client] && !resetHurt[iAttacker] && hurtedPlayer1[iAttacker] > 0 && hurtedPlayer2[iAttacker] > 0) {
-			resetHurt[iAttacker] = true;
-			hurtedPlayer1[iAttacker] = client;
-		} else if (iAttacker != hurtedPlayer2[client]  && iAttacker != hurtedPlayer1[client] && resetHurt[iAttacker] && hurtedPlayer1[iAttacker] > 0 && hurtedPlayer2[iAttacker] > 0) {
-			resetHurt[iAttacker] = false;
-			hurtedPlayer2[iAttacker] = client;
+		if (g_bHurtedPlayer1[iAttacker] == -1 && iAttacker != g_bHurtedPlayer1[client]) {
+			g_bHurtedPlayer1[iAttacker] = client;
+		} else if (g_bHurtedPlayer2[iAttacker] == -1 && iAttacker != g_bHurtedPlayer2[client] && iAttacker != g_bHurtedPlayer1[client]) {
+			g_bHurtedPlayer2[iAttacker] = client;
+		} else if (iAttacker != g_bHurtedPlayer1[client] && !g_bResetHurt[iAttacker] && g_bHurtedPlayer1[iAttacker] > 0 && g_bHurtedPlayer2[iAttacker] > 0) {
+			g_bResetHurt[iAttacker] = true;
+			g_bHurtedPlayer2[iAttacker] = client;
+		} else if (iAttacker != g_bHurtedPlayer2[client]  && iAttacker != g_bHurtedPlayer2[client] && g_bResetHurt[iAttacker] && g_bHurtedPlayer2[iAttacker] > 0 && hurtedPlayer2[iAttacker] > 0) {
+			g_bResetHurt[iAttacker] = false;
+			g_bHurtedPlayer2[iAttacker] = client;
 		}
 	}
 }

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -2750,45 +2750,21 @@ public Action Event_PlayerHurt(Event event, const char[] name, bool dontBroadcas
 		return;
 	}
 	
-	if (g_iRole[iAttacker] == TTT_TEAM_INNOCENT && g_iRole[client] == TTT_TEAM_INNOCENT)
+	if ((g_iRole[iAttacker] == TTT_TEAM_INNOCENT && g_iRole[client] == TTT_TEAM_INNOCENT) ||
+	   (g_iRole[iAttacker] == TTT_TEAM_INNOCENT && g_iRole[client] == TTT_TEAM_DETECTIVE) ||
+	   (g_iRole[iAttacker] == TTT_TEAM_TRAITOR && g_iRole[client] == TTT_TEAM_TRAITOR)    ||
+	   (g_iRole[iAttacker] == TTT_TEAM_DETECTIVE && g_iRole[client] == TTT_TEAM_INNOCENT) ||
+	   (g_iRole[iAttacker] == TTT_TEAM_DETECTIVE && g_iRole[client] == TTT_TEAM_DETECTIVE))
 	{
 		if (hurtedPlayer1[iAttacker] == -1 && iAttacker != hurtedPlayer1[client]) {
 			hurtedPlayer1[iAttacker] = client;
 		} else if (hurtedPlayer2[iAttacker] == -1 && iAttacker != hurtedPlayer2[client] && iAttacker != hurtedPlayer1[client]) {
 			hurtedPlayer2[iAttacker] = client;
-		} else if (iAttacker != hurtedPlayer1[client] && !renewHurt[iAttacker] && hurtedPlayer1[iAttacker] > 0 && hurtedPlayer2[iAttacker] > 0) {
-			renewHurt[iAttacker] = true;
+		} else if (iAttacker != hurtedPlayer1[client] && !resetHurt[iAttacker] && hurtedPlayer1[iAttacker] > 0 && hurtedPlayer2[iAttacker] > 0) {
+			resetHurt[iAttacker] = true;
 			hurtedPlayer1[iAttacker] = client;
-		} else if (iAttacker != hurtedPlayer2[client]  && iAttacker != hurtedPlayer1[client] && renewHurt[iAttacker] && hurtedPlayer1[iAttacker] > 0 && hurtedPlayer2[iAttacker] > 0) {
-			renewHurt[iAttacker] = false;
-			hurtedPlayer2[iAttacker] = client;
-		}
-	}
-	else if (g_iRole[iAttacker] == TTT_TEAM_TRAITOR && g_iRole[client] == TTT_TEAM_TRAITOR)
-	{
-		if (hurtedPlayer1[iAttacker] == -1 && iAttacker != hurtedPlayer1[client]) {
-		    hurtedPlayer1[iAttacker] = client;
-		} else if (hurtedPlayer2[iAttacker] == -1 && iAttacker != hurtedPlayer2[client] && client != hurtedPlayer1[iAttacker]) {
-		    hurtedPlayer2[iAttacker] = client;
-		} else if (iAttacker != hurtedPlayer1[client] && !renewHurt[iAttacker] && client != hurtedPlayer1[iAttacker]) {
-		    renewHurt[iAttacker] = true;
-		    hurtedPlayer1[iAttacker] = client;
-		} else if (iAttacker != hurtedPlayer2[client] && renewHurt[iAttacker] && client != hurtedPlayer2[iAttacker] && client != hurtedPlayer1[iAttacker]) {
-		    renewHurt[iAttacker] = false;
-		    hurtedPlayer2[iAttacker] = client;
-		}
-	}
-	else if (g_iRole[iAttacker] == TTT_TEAM_DETECTIVE && g_iRole[client] == TTT_TEAM_DETECTIVE)
-	{
-		if (hurtedPlayer1[iAttacker] == -1 && iAttacker != hurtedPlayer1[client]) {
-			hurtedPlayer1[iAttacker] = client;
-		} else if (hurtedPlayer2[iAttacker] == -1 && iAttacker != hurtedPlayer2[client] && client != hurtedPlayer1[iAttacker]) {
-			hurtedPlayer2[iAttacker] = client;
-		} else if (iAttacker != hurtedPlayer1[client] && !renewHurt[iAttacker] && client != hurtedPlayer1[iAttacker]) {
-			renewHurt[iAttacker] = true;
-			hurtedPlayer1[iAttacker] = client;
-		} else if (iAttacker != hurtedPlayer2[client] && renewHurt[iAttacker] && client != hurtedPlayer2[iAttacker] && client != hurtedPlayer1[iAttacker]) {
-			renewHurt[iAttacker] = false;
+		} else if (iAttacker != hurtedPlayer2[client]  && iAttacker != hurtedPlayer1[client] && resetHurt[iAttacker] && hurtedPlayer1[iAttacker] > 0 && hurtedPlayer2[iAttacker] > 0) {
+			resetHurt[iAttacker] = false;
 			hurtedPlayer2[iAttacker] = client;
 		}
 	}

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -81,6 +81,8 @@ public void OnPluginStart()
 	AddCommandListener(Command_InterceptSuicide, "spectate");
 	AddCommandListener(Command_InterceptSuicide, "jointeam");
 	AddCommandListener(Command_InterceptSuicide, "joinclass");
+	AddCommandListener(Command_InterceptSuicide, "explodevector");
+	AddCommandListener(Command_InterceptSuicide, "killvector");
 	
 	for (int i = 0; i < sizeof(g_sRadioCMDs); i++)
 	{
@@ -96,6 +98,7 @@ public void OnPluginStart()
 	HookEvent("player_spawn", Event_PlayerSpawn);
 	HookEvent("player_changename", Event_ChangeName);
 	HookEvent("player_death", Event_PlayerDeath);
+	HookEvent("player_hurt", Event_PlayerHurt);
 	HookEvent("cs_win_panel_round", Event_WinPanel);
 	HookEvent("cs_win_panel_match", Event_WinPanel);
 	HookEvent("cs_match_end_restart", Event_WinPanel);
@@ -590,6 +593,10 @@ public Action Event_RoundStartPre(Event event, const char[] name, bool dontBroad
 		g_iTraitorKills[i] = 0;
 		g_iDetectiveKills[i] = 0;
 		g_bImmuneRDMManager[i] = false;
+		
+		hurtedPlayer1[i] = -1;
+		hurtedPlayer2[i] = -1;
+		resetHurt[i] = false;
 		
 		DispatchKeyValue(i, "targetname", "UNASSIGNED");
 		CS_SetClientClanTag(i, " ");
@@ -2621,8 +2628,14 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 	{
 		Format(iItem, sizeof(iItem), "-> [%N%s (Innocent) killed %N%s (Innocent) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
-
-		subtractKarma(iAttacker, g_ckarmaII.IntValue, true);
+		
+		if (hurtedPlayer1[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
+		} else if (hurtedPlayer2[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
+		} else {
+			subtractKarma(iAttacker, g_ckarmaII.IntValue, true);
+		}
 	}
 	else if (g_iRole[iAttacker] == TTT_TEAM_INNOCENT && g_iRole[client] == TTT_TEAM_TRAITOR)
 	{
@@ -2635,8 +2648,14 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 	{
 		Format(iItem, sizeof(iItem), "-> [%N%s (Innocent) killed %N%s (Detective) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
-
-		subtractKarma(iAttacker, g_ckarmaID.IntValue, true);
+		
+		if (hurtedPlayer1[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
+		} else if (hurtedPlayer2[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
+		} else {
+			subtractKarma(iAttacker, g_ckarmaID.IntValue, true);
+		}
 	}
 	else if (g_iRole[iAttacker] == TTT_TEAM_TRAITOR && g_iRole[client] == TTT_TEAM_INNOCENT)
 	{
@@ -2649,8 +2668,14 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 	{
 		Format(iItem, sizeof(iItem), "-> [%N%s (Traitor) killed %N%s (Traitor) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
-
-		subtractKarma(iAttacker, g_ckarmaTT.IntValue, true);
+		
+		if (hurtedPlayer1[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt traitor");
+		} else if (hurtedPlayer2[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt traitor");
+		} else {
+			subtractKarma(iAttacker, g_ckarmaTT.IntValue, true);
+		}
 	}
 	else if (g_iRole[iAttacker] == TTT_TEAM_TRAITOR && g_iRole[client] == TTT_TEAM_DETECTIVE)
 	{
@@ -2663,8 +2688,14 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 	{
 		Format(iItem, sizeof(iItem), "-> [%N%s (Detective) killed %N%s (Innocent) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
-
-		subtractKarma(iAttacker, g_ckarmaDI.IntValue, true);
+		
+		if (hurtedPlayer1[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
+		} else if (hurtedPlayer2[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
+		} else {
+			subtractKarma(iAttacker, g_ckarmaDI.IntValue, true);
+		}
 	}
 	else if (g_iRole[iAttacker] == TTT_TEAM_DETECTIVE && g_iRole[client] == TTT_TEAM_TRAITOR)
 	{
@@ -2677,8 +2708,14 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 	{
 		Format(iItem, sizeof(iItem), "-> [%N%s (Detective) killed %N%s (Detective) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
-
-		subtractKarma(iAttacker, g_ckarmaDD.IntValue, true);
+		
+		if (hurtedPlayer1[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
+		} else if (hurtedPlayer2[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
+		} else {
+			subtractKarma(iAttacker, g_ckarmaDD.IntValue, true);
+		}
 	}
 
 	if (g_iRole[client] == TTT_TEAM_UNASSIGNED)
@@ -2693,6 +2730,68 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 	Call_PushCell(client);
 	Call_PushCell(iAttacker);
 	Call_Finish();
+}
+
+public Action Event_PlayerHurt(Event event, const char[] name, bool dontBroadcast)
+{
+	int client = GetClientOfUserId(event.GetInt("userid"));
+	if (!TTT_IsClientValid(client))
+	{
+		return;
+	}
+	
+	int iAttacker = GetClientOfUserId(event.GetInt("attacker"));
+	if (!TTT_IsClientValid(iAttacker) || iAttacker == client)
+	{
+		return;
+	}
+	
+	if (g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		return;
+	}
+	
+	if (g_iRole[iAttacker] == TTT_TEAM_INNOCENT && g_iRole[client] == TTT_TEAM_INNOCENT)
+	{
+		if (hurtedPlayer1[iAttacker] == -1 && iAttacker != hurtedPlayer1[client]) {
+			hurtedPlayer1[iAttacker] = client;
+		} else if (hurtedPlayer2[iAttacker] == -1 && iAttacker != hurtedPlayer2[client] && iAttacker != hurtedPlayer1[client]) {
+			hurtedPlayer2[iAttacker] = client;
+		} else if (iAttacker != hurtedPlayer1[client] && !renewHurt[iAttacker] && hurtedPlayer1[iAttacker] > 0 && hurtedPlayer2[iAttacker] > 0) {
+			renewHurt[iAttacker] = true;
+			hurtedPlayer1[iAttacker] = client;
+		} else if (iAttacker != hurtedPlayer2[client]  && iAttacker != hurtedPlayer1[client] && renewHurt[iAttacker] && hurtedPlayer1[iAttacker] > 0 && hurtedPlayer2[iAttacker] > 0) {
+			renewHurt[iAttacker] = false;
+			hurtedPlayer2[iAttacker] = client;
+		}
+	}
+	else if (g_iRole[iAttacker] == TTT_TEAM_TRAITOR && g_iRole[client] == TTT_TEAM_TRAITOR)
+	{
+		if (hurtedPlayer1[iAttacker] == -1 && iAttacker != hurtedPlayer1[client]) {
+		    hurtedPlayer1[iAttacker] = client;
+		} else if (hurtedPlayer2[iAttacker] == -1 && iAttacker != hurtedPlayer2[client] && client != hurtedPlayer1[iAttacker]) {
+		    hurtedPlayer2[iAttacker] = client;
+		} else if (iAttacker != hurtedPlayer1[client] && !renewHurt[iAttacker] && client != hurtedPlayer1[iAttacker]) {
+		    renewHurt[iAttacker] = true;
+		    hurtedPlayer1[iAttacker] = client;
+		} else if (iAttacker != hurtedPlayer2[client] && renewHurt[iAttacker] && client != hurtedPlayer2[iAttacker] && client != hurtedPlayer1[iAttacker]) {
+		    renewHurt[iAttacker] = false;
+		    hurtedPlayer2[iAttacker] = client;
+		}
+	}
+	else if (g_iRole[iAttacker] == TTT_TEAM_DETECTIVE && g_iRole[client] == TTT_TEAM_DETECTIVE)
+	{
+		if (hurtedPlayer1[iAttacker] == -1 && iAttacker != hurtedPlayer1[client]) {
+			hurtedPlayer1[iAttacker] = client;
+		} else if (hurtedPlayer2[iAttacker] == -1 && iAttacker != hurtedPlayer2[client] && client != hurtedPlayer1[iAttacker]) {
+			hurtedPlayer2[iAttacker] = client;
+		} else if (iAttacker != hurtedPlayer1[client] && !renewHurt[iAttacker] && client != hurtedPlayer1[iAttacker]) {
+			renewHurt[iAttacker] = true;
+			hurtedPlayer1[iAttacker] = client;
+		} else if (iAttacker != hurtedPlayer2[client] && renewHurt[iAttacker] && client != hurtedPlayer2[iAttacker] && client != hurtedPlayer1[iAttacker]) {
+			renewHurt[iAttacker] = false;
+			hurtedPlayer2[iAttacker] = client;
+		}
+	}
 }
 
 public void OnMapEnd()

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -2629,9 +2629,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		Format(iItem, sizeof(iItem), "-> [%N%s (Innocent) killed %N%s (Innocent) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
 		
-		if (hurtedPlayer1[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		if (hurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
-		} else if (hurtedPlayer2[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		} else if (hurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
 		} else {
 			subtractKarma(iAttacker, g_ckarmaII.IntValue, true);
@@ -2649,9 +2649,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		Format(iItem, sizeof(iItem), "-> [%N%s (Innocent) killed %N%s (Detective) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
 		
-		if (hurtedPlayer1[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		if (hurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
-		} else if (hurtedPlayer2[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		} else if (hurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
 		} else {
 			subtractKarma(iAttacker, g_ckarmaID.IntValue, true);
@@ -2669,9 +2669,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		Format(iItem, sizeof(iItem), "-> [%N%s (Traitor) killed %N%s (Traitor) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
 		
-		if (hurtedPlayer1[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		if (hurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt traitor");
-		} else if (hurtedPlayer2[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		} else if (hurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt traitor");
 		} else {
 			subtractKarma(iAttacker, g_ckarmaTT.IntValue, true);
@@ -2689,9 +2689,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		Format(iItem, sizeof(iItem), "-> [%N%s (Detective) killed %N%s (Innocent) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
 		
-		if (hurtedPlayer1[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		if (hurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
-		} else if (hurtedPlayer2[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		} else if (hurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt innocent");
 		} else {
 			subtractKarma(iAttacker, g_ckarmaDI.IntValue, true);
@@ -2709,9 +2709,9 @@ public Action Event_PlayerDeath(Event event, const char[] name, bool dontBroadca
 		Format(iItem, sizeof(iItem), "-> [%N%s (Detective) killed %N%s (Detective) with %s] - BAD ACTION", iAttacker, sAttackerID, client, sClientID, sWeapon);
 		addArrayTime(iItem);
 		
-		if (hurtedPlayer1[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		if (hurtedPlayer1[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
-		} else if (hurtedPlayer2[client] == iAttacker && g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
+		} else if (hurtedPlayer2[client] == iAttacker && !g_cKarmaDecreaseWhenKillPlayerWhoHurt.BoolValue) {
 			CPrintToChat(client, "%s %T", g_sTag, "No karma hurt detective");
 		} else {
 			subtractKarma(iAttacker, g_ckarmaDD.IntValue, true);

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -2762,8 +2762,8 @@ public Action Event_PlayerHurt(Event event, const char[] name, bool dontBroadcas
 			g_bHurtedPlayer2[iAttacker] = client;
 		} else if (iAttacker != g_bHurtedPlayer1[client] && !g_bResetHurt[iAttacker] && g_bHurtedPlayer1[iAttacker] > 0 && g_bHurtedPlayer2[iAttacker] > 0) {
 			g_bResetHurt[iAttacker] = true;
-			g_bHurtedPlayer2[iAttacker] = client;
-		} else if (iAttacker != g_bHurtedPlayer2[client]  && iAttacker != g_bHurtedPlayer2[client] && g_bResetHurt[iAttacker] && g_bHurtedPlayer2[iAttacker] > 0 && hurtedPlayer2[iAttacker] > 0) {
+			g_bHurtedPlayer1[iAttacker] = client;
+		} else if (iAttacker != g_bHurtedPlayer2[client]  && iAttacker != g_bHurtedPlayer1[client] && g_bResetHurt[iAttacker] && g_bHurtedPlayer1[iAttacker] > 0 && g_bHurtedPlayer2[iAttacker] > 0) {
 			g_bResetHurt[iAttacker] = false;
 			g_bHurtedPlayer2[iAttacker] = client;
 		}

--- a/addons/sourcemod/translations/pt/ttt.phrases.txt
+++ b/addons/sourcemod/translations/pt/ttt.phrases.txt
@@ -767,5 +767,144 @@
 	{
 		"pt"		"Você encontrou um corpo de chamariz! CORRE!"
 	}
+	
+	"Player Spawn TTT Version"
+	{
+		"#format"	"{1:s}"
+		"en"		"Trouble in Terrorist Town - Versão: {1}"
+	}
 
+	"TTT Radio Menu: Commands"
+	{
+		"en"		"TTT Comandos de Rádio"
+	}
+
+	"TTT Radio Menu: Yes"
+	{
+		"en"		"Sim"
+	}
+
+	"TTT Radio Menu: No"
+	{
+		"en"		"Não"
+	}
+
+	"TTT Radio Menu: Maybe"
+	{
+		"en"		"Talvez"
+	}
+
+	"TTT Radio Menu: Help"
+	{
+		"en"		"Ajuda"
+	}
+
+	"TTT Radio Menu: Check"
+	{
+		"en"		"Verifique"
+	}
+
+	"TTT Radio Menu: Im With"
+	{
+		"en"		"Estou com..."
+	}
+
+	"TTT Radio Menu: Suspect"
+	{
+		"en"		"Suspeito..."
+	}
+
+	"TTT Radio Menu: Traitor"
+	{
+		"en"		"Traidor..."
+	}
+
+	"TTT Radio Menu: Innocent"
+	{
+		"en"		"Inocente..."
+	}
+
+	"TTT Radio Menu: See"
+	{
+		"en"		"Veja..."
+	}
+
+	"TTT Radio: Yes"
+	{
+		"en"		"Sim"
+	}
+
+	"TTT Radio: No"
+	{
+		"en"		"Não"
+	}
+
+	"TTT Radio: Maybe"
+	{
+		"en"		"Talvez"
+	}
+
+	"TTT Radio: Help"
+	{
+		"en"		"Ajuda"
+	}
+
+	"TTT Radio: Check"
+	{
+		"en"		"Verifique"
+	}
+
+	"TTT Radio: Im With"
+	{
+		"en"		"Estou com {1}"
+	}
+
+	"TTT Radio: Suspect"
+	{
+		"en"		"{1} age de forma suspeita."
+	}
+
+	"TTT Radio: Traitor"
+	{
+		"#format"	"{1:N}"
+		"en"		"{1} é o traidor!"
+	}
+
+	"TTT Radio: Innocent"
+	{
+		"#format"	"{1:N}"
+		"en"		"{1} é inocente."
+	}
+
+	"TTT Radio: See"
+	{
+		"#format"	"{1:N}"
+		"en"		"Eu vejo {1}"
+	}
+
+	"Random Teleporter: Cant find ragdoll"
+	{
+		"en"		"Não foi possível encontrar um corpo"
+	}
+
+	"Random Teleporter: Teleport"
+	{
+		"#format"	"{1:N}"
+		"en"		"Vocë trocou de posições com {green}{1}"
+	}
+	
+	"No karma hurt innocent"
+	{
+		"en"		"You didn't lose Karma because the {green}INNOCENT {lightgreen}hurted you before."
+	}
+	
+	"No karma hurt traitor"
+	{
+		"en"		"You didn't lose Karma because the {darkred}TRAITOR {lightgreen}hurted you before."
+	}
+	
+	"No karma hurt innocent"
+	{
+		"en"		"You didn't lose Karma because the {darkblue}DETECTIVE {lightgreen}hurted you before."
+	}
 }

--- a/addons/sourcemod/translations/ttt.phrases.txt
+++ b/addons/sourcemod/translations/ttt.phrases.txt
@@ -983,5 +983,19 @@
 		"#format"	"{1:N}"
 		"en"		"You switched the position with {green}{1}"
 	}
-
+	
+	"No karma hurt innocent"
+	{
+		"en"		"You didn't lose Karma because the {green}INNOCENT {lightgreen}hurted you before."
+	}
+	
+	"No karma hurt traitor"
+	{
+		"en"		"You didn't lose Karma because the {darkred}TRAITOR {lightgreen}hurted you before."
+	}
+	
+	"No karma hurt innocent"
+	{
+		"en"		"You didn't lose Karma because the {darkblue}DETECTIVE {lightgreen}hurted you before."
+	}
 }


### PR DESCRIPTION
By default everyone will lose karma if they kill the wrong person.

If they disable the new cvar, it will enable the feature that it will avoid losing karma if you kill the last 2 persons that shoot at you.

Also added 2 extra verifications to avoid suicide.

I haven't tested this with the cvar, but I've been using this for a while and it's working.