### PR TITLE
Silent ID Feature

### DIFF
--- a/addons/sourcemod/scripting/include/ttt.inc
+++ b/addons/sourcemod/scripting/include/ttt.inc
@@ -108,6 +108,7 @@ forward Action TTT_OnClientDeathPre(int victim, int attacker);
  * @param client            The client who identified the body.
  * @param victim            The client whom the body belongs to. (-1 for invalid index)
  * @param deadPlayer        The name of the victim.
+ * @param silentID          True if body was silenced id and false if normal inspect
  */
 forward void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, bool silentID);
 

--- a/addons/sourcemod/scripting/include/ttt.inc
+++ b/addons/sourcemod/scripting/include/ttt.inc
@@ -109,7 +109,7 @@ forward Action TTT_OnClientDeathPre(int victim, int attacker);
  * @param victim            The client whom the body belongs to. (-1 for invalid index)
  * @param deadPlayer        The name of the victim.
  */
-forward void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer);
+forward void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, int isBodySilecedID = 0);
 
 /*
  * Called when a body is scanned (by a Detective - not really? (Line 2761-2765 ttt.sp) -).

--- a/addons/sourcemod/scripting/include/ttt.inc
+++ b/addons/sourcemod/scripting/include/ttt.inc
@@ -109,7 +109,7 @@ forward Action TTT_OnClientDeathPre(int victim, int attacker);
  * @param victim            The client whom the body belongs to. (-1 for invalid index)
  * @param deadPlayer        The name of the victim.
  */
-forward void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, bool silentID = false);
+forward void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, bool silentID);
 
 /*
  * Called when a body is scanned (by a Detective - not really? (Line 2761-2765 ttt.sp) -).

--- a/addons/sourcemod/scripting/include/ttt.inc
+++ b/addons/sourcemod/scripting/include/ttt.inc
@@ -109,7 +109,7 @@ forward Action TTT_OnClientDeathPre(int victim, int attacker);
  * @param victim            The client whom the body belongs to. (-1 for invalid index)
  * @param deadPlayer        The name of the victim.
  */
-forward void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, int isBodySilecedID = 0);
+forward void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, bool silentID = false);
 
 /*
  * Called when a body is scanned (by a Detective - not really? (Line 2761-2765 ttt.sp) -).

--- a/addons/sourcemod/scripting/ttt/core/config.sp
+++ b/addons/sourcemod/scripting/ttt/core/config.sp
@@ -128,7 +128,6 @@ void SetupConfig()
 	g_cSilentIdEnabled = AutoExecConfig_CreateConVar("ttt_silent_id", "0", "0 = Disabled. 1 = Enable silent id (+speed and +use together). Silent ID wont print on chat when someone inspects a body.", _, true, 0.0, true, 1.0);
 	g_cSilentIdColor = AutoExecConfig_CreateConVar("ttt_silent_id_color", "1", "0 = Disabled, will not change the color of the body. 1 = Silent ID will color the body when inspecting. (Green = Innocent, Red = Traitor, Blue = Detective)", _, true, 0.0, true, 1.0);
 	g_cSilentIdRoles = AutoExecConfig_CreateConVar("ttt_silent_id_roles", "14", "2 = Innocent. 4 = Traitor. 8 = Detective. For other combinations, just sum the values. (i.e.: 14 (2+4+8) = All roles can Silent ID)", _, true, 0.0, true, 1.0);
-	g_cSilentIdRewards = AutoExecConfig_CreateConVar("ttt_silent_id_rewards", "1", "0 = Disabled, will not reward credits with silent id. 1 = Will reward the client with credits for inspecting the body.", _, true, 0.0, true, 1.0);
 	
 	g_cpluginTag.AddChangeHook(OnConVarChanged);
 	g_ckickImmunity.AddChangeHook(OnConVarChanged);

--- a/addons/sourcemod/scripting/ttt/core/config.sp
+++ b/addons/sourcemod/scripting/ttt/core/config.sp
@@ -127,7 +127,7 @@ void SetupConfig()
 	g_cKarmaDecreaseWhenKillPlayerWhoHurt = AutoExecConfig_CreateConVar("ttt_karma_decrease_kill_player_who_hurted", "1", "Decrease Karma when you kill a player who hurted you?.", _, true, 0.0, true, 1.0);
 	g_cSilentIdEnabled = AutoExecConfig_CreateConVar("ttt_silent_id", "0", "0 = Disabled. 1 = Enable silent id (+speed and +use together). Silent ID wont print on chat when someone inspects a body.", _, true, 0.0, true, 1.0);
 	g_cSilentIdColor = AutoExecConfig_CreateConVar("ttt_silent_id_color", "1", "0 = Disabled, will not change the color of the body. 1 = Silent ID will color the body when inspecting. (Green = Innocent, Red = Traitor, Blue = Detective)", _, true, 0.0, true, 1.0);
-	g_cSilentIdRoles = AutoExecConfig_CreateConVar("ttt_silent_id_roles", "14", "2 = Innocent. 4 = Traitor. 8 = Detective. For other combinations, just sum the values. (i.e.: 14 (2+4+8) = All roles can Silent ID)", _, true, 0.0, true, 1.0);
+	g_cSilentIdRoles = AutoExecConfig_CreateConVar("ttt_silent_id_roles", "14", "2 = Innocent. 4 = Traitor. 8 = Detective. For other combinations, just sum the values. (i.e.: 14 (2+4+8) = All roles can Silent ID)");	
 	
 	g_cpluginTag.AddChangeHook(OnConVarChanged);
 	g_ckickImmunity.AddChangeHook(OnConVarChanged);

--- a/addons/sourcemod/scripting/ttt/core/config.sp
+++ b/addons/sourcemod/scripting/ttt/core/config.sp
@@ -125,6 +125,10 @@ void SetupConfig()
 	g_cDoublePushInno = AutoExecConfig_CreateConVar("ttt_double_push_innocents", "1", "Push innocents (from last round) two times into players array? This should increase the chance to get traitor in the new round.", _, true, 0.0, true, 1.0);
 	g_cDoublePushDete = AutoExecConfig_CreateConVar("ttt_double_push_detective", "1", "Push detective (from last round) two times into players array? This should increase the chance to get traitor in the new round.", _, true, 0.0, true, 1.0);
 	g_cKarmaDecreaseWhenKillPlayerWhoHurt = AutoExecConfig_CreateConVar("ttt_karma_decrease_kill_player_who_hurted", "1", "Decrease Karma when you kill a player who hurted you?.", _, true, 0.0, true, 1.0);
+	g_cSilentIdEnabled = AutoExecConfig_CreateConVar("ttt_silent_id", "0", "0 = Disabled. 1 = Enable silent id (+speed and +use together). Silent ID wont print on chat when someone inspects a body.", _, true, 0.0, true, 1.0);
+	g_cSilentIdColor = AutoExecConfig_CreateConVar("ttt_silent_id_color", "1", "0 = Disabled, will not change the color of the body. 1 = Silent ID will color the body when inspecting. (Green = Innocent, Red = Traitor, Blue = Detective)", _, true, 0.0, true, 1.0);
+	g_cSilentIdRoles = AutoExecConfig_CreateConVar("ttt_silent_id_roles", "0", "0 = All roles can silent id. 1 = Innocent Only. 2 = Traitor Only. 3 = Detective Only. 12 = Innocent and Traitor. 23 = Traitor and Detective.", _, true, 0.0, true, 1.0);
+	g_cSilentIdRewards = AutoExecConfig_CreateConVar("ttt_silent_id_rewards", "1", "0 = Disabled, will not reward credits with silent id. 1 = Will reward the client with credits for inspecting the body.", _, true, 0.0, true, 1.0);
 	
 	g_cpluginTag.AddChangeHook(OnConVarChanged);
 	g_ckickImmunity.AddChangeHook(OnConVarChanged);

--- a/addons/sourcemod/scripting/ttt/core/config.sp
+++ b/addons/sourcemod/scripting/ttt/core/config.sp
@@ -127,7 +127,7 @@ void SetupConfig()
 	g_cKarmaDecreaseWhenKillPlayerWhoHurt = AutoExecConfig_CreateConVar("ttt_karma_decrease_kill_player_who_hurted", "1", "Decrease Karma when you kill a player who hurted you?.", _, true, 0.0, true, 1.0);
 	g_cSilentIdEnabled = AutoExecConfig_CreateConVar("ttt_silent_id", "0", "0 = Disabled. 1 = Enable silent id (+speed and +use together). Silent ID wont print on chat when someone inspects a body.", _, true, 0.0, true, 1.0);
 	g_cSilentIdColor = AutoExecConfig_CreateConVar("ttt_silent_id_color", "1", "0 = Disabled, will not change the color of the body. 1 = Silent ID will color the body when inspecting. (Green = Innocent, Red = Traitor, Blue = Detective)", _, true, 0.0, true, 1.0);
-	g_cSilentIdRoles = AutoExecConfig_CreateConVar("ttt_silent_id_roles", "0", "0 = All roles can silent id. 1 = Innocent Only. 2 = Traitor Only. 3 = Detective Only. 12 = Innocent and Traitor. 23 = Traitor and Detective.", _, true, 0.0, true, 1.0);
+	g_cSilentIdRoles = AutoExecConfig_CreateConVar("ttt_silent_id_roles", "14", "2 = Innocent. 4 = Traitor. 8 = Detective. For other combinations, just sum the values. (i.e.: 14 (2+4+8) = All roles can Silent ID)", _, true, 0.0, true, 1.0);
 	g_cSilentIdRewards = AutoExecConfig_CreateConVar("ttt_silent_id_rewards", "1", "0 = Disabled, will not reward credits with silent id. 1 = Will reward the client with credits for inspecting the body.", _, true, 0.0, true, 1.0);
 	
 	g_cpluginTag.AddChangeHook(OnConVarChanged);

--- a/addons/sourcemod/scripting/ttt/core/globals.sp
+++ b/addons/sourcemod/scripting/ttt/core/globals.sp
@@ -280,7 +280,6 @@ ConVar g_cKarmaDecreaseWhenKillPlayerWhoHurt = null;
 ConVar g_cSilentIdEnabled = null;
 ConVar g_cSilentIdColor = null;
 ConVar g_cSilentIdRoles = null;
-ConVar g_cSilentIdRewards = null;
 
 Handle g_hRules = null;
 bool g_bRules[MAXPLAYERS + 1] =  { false, ... };

--- a/addons/sourcemod/scripting/ttt/core/globals.sp
+++ b/addons/sourcemod/scripting/ttt/core/globals.sp
@@ -277,6 +277,10 @@ ConVar g_cDamageKarmaDD = null;
 ConVar g_cDoublePushInno = null;
 ConVar g_cDoublePushDete = null;
 ConVar g_cKarmaDecreaseWhenKillPlayerWhoHurt = null;
+ConVar g_cSilentIdEnabled = null;
+ConVar g_cSilentIdColor = null;
+ConVar g_cSilentIdRoles = null;
+ConVar g_cSilentIdRewards = null;
 
 Handle g_hRules = null;
 bool g_bRules[MAXPLAYERS + 1] =  { false, ... };

--- a/addons/sourcemod/scripting/ttt/core/natives.sp
+++ b/addons/sourcemod/scripting/ttt/core/natives.sp
@@ -7,7 +7,7 @@ void InitForwards()
 	g_hOnClientGetRole = CreateGlobalForward("TTT_OnClientGetRole", ET_Ignore, Param_Cell, Param_Cell);
 	g_hOnClientDeath = CreateGlobalForward("TTT_OnClientDeath", ET_Ignore, Param_Cell, Param_Cell);
 	g_hOnClientDeathPre = CreateGlobalForward("TTT_OnClientDeathPre", ET_Event, Param_Cell, Param_Cell);
-	g_hOnBodyFound = CreateGlobalForward("TTT_OnBodyFound", ET_Ignore, Param_Cell, Param_Cell, Param_String);
+	g_hOnBodyFound = CreateGlobalForward("TTT_OnBodyFound", ET_Ignore, Param_Cell, Param_Cell, Param_String, Param_Cell);
 	g_hOnBodyChecked = CreateGlobalForward("TTT_OnBodyChecked", ET_Event, Param_Cell, Param_Array);
 	g_hOnButtonPress = CreateGlobalForward("TTT_OnButtonPress", ET_Ignore, Param_Cell, Param_Cell);
 	g_hOnButtonRelease = CreateGlobalForward("TTT_OnButtonRelease", ET_Ignore, Param_Cell, Param_Cell);

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -2992,6 +2992,7 @@ public int TTT_OnButtonPress(int client, int button)
 							bool bSilentID = g_cSilentIdEnabled.BoolValue;
 							bool bInWalk = button & IN_WALK != 0;
 							bool bSilentColor = g_cSilentIdColor.BoolValue;
+							int iAllowedRolesSilentID = g_cSilentIdRoles.IntValue;
 							bool silentID = false;
 							
 							iRagdollC[Found] = true;
@@ -3015,7 +3016,7 @@ public int TTT_OnButtonPress(int client, int button)
 							
 							if (iRagdollC[VictimTeam] == TTT_TEAM_INNOCENT)
 							{
-								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, g_iRole[client]))
+								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, iAllowedRolesSilentID)))
 								{
 									LoopValidClients(j)
 									{
@@ -3043,7 +3044,7 @@ public int TTT_OnButtonPress(int client, int button)
 							}
 							else if (iRagdollC[VictimTeam] == TTT_TEAM_DETECTIVE)
 							{
-								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, g_iRole[client]))
+								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, iAllowedRolesSilentID)))
 								{
 									LoopValidClients(j)
 									{
@@ -3058,7 +3059,7 @@ public int TTT_OnButtonPress(int client, int button)
 								{
 								    CPrintToChat(client, "%s %T", g_sTag, "Found Detective", client, client, iRagdollC[VictimName]);
 								    
-								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Detective) - SILENT", client, sRole, iRagdollC[VictimName])
+								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Detective) - SILENT", client, sRole, iRagdollC[VictimName]);
 								    
 								    if (bSilentColor) {
 								    	SetEntityRenderColor(iEntity, 0, 0, 255, 255);
@@ -3071,7 +3072,7 @@ public int TTT_OnButtonPress(int client, int button)
 							}
 							else if (iRagdollC[VictimTeam] == TTT_TEAM_TRAITOR)
 							{
-								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, g_iRole[client]))
+								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, iAllowedRolesSilentID)))
 								{
 									LoopValidClients(j)
 									{

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -3115,7 +3115,7 @@ public int TTT_OnButtonPress(int client, int button)
 							}
 							
 							Call_PushString(iRagdollC[VictimName]);
-							Call_PushCell(silentID);
+							Call_PushCell(view_as<int>(silentID));
 							Call_Finish();
 						}
 						g_aRagdoll.SetArray(i, iRagdollC[0]);

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -2094,7 +2094,6 @@ stock void ShowRules(int client, int iItem)
 	{
 		SetFailState("Can't read %s correctly! (ImportFromFile)", g_sRulesFile);
 		delete kvRules;
-		delete hFile;
 		return;
 	}
 
@@ -2102,7 +2101,6 @@ stock void ShowRules(int client, int iItem)
 	{
 		SetFailState("Can't read %s correctly! (GotoFirstSubKey)", g_sRulesFile);
 		delete kvRules;
-		delete hFile;
 		return;
 	}
 
@@ -2989,6 +2987,11 @@ public int TTT_OnButtonPress(int client, int button)
 
 						if (!iRagdollC[Found] && IsPlayerAlive(client))
 						{
+							bool bSilentID = g_cSilentIdEnabled.BoolValue;
+							bool bInWalk = button & IN_WALK != 0;
+							bool bSilentColor = g_cSilentIdColor.BoolValue;
+							int iBodyWasSilentID = 0;
+							
 							iRagdollC[Found] = true;
 
 							bool bValid = false;
@@ -3010,35 +3013,86 @@ public int TTT_OnButtonPress(int client, int button)
 							
 							if (iRagdollC[VictimTeam] == TTT_TEAM_INNOCENT)
 							{
-								LoopValidClients(j)
+								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, g_iRole[client]))
 								{
-									CPrintToChat(j, "%s %T", g_sTag, "Found Innocent", j, client, iRagdollC[VictimName]);
+									LoopValidClients(j)
+									{
+										CPrintToChat(j, "%s %T", g_sTag, "Found Innocent", j, client, iRagdollC[VictimName]);
+									}
+									
+									Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Innocent)", client, sRole, iRagdollC[VictimName]);
+									
+									SetEntityRenderColor(iEntity, 0, 255, 0, 255);
 								}
-
-								SetEntityRenderColor(iEntity, 0, 255, 0, 255);
-								Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Innocent)", client, sRole, iRagdollC[VictimName]);
+								else
+								{
+								    CPrintToChat(client, "%s %T", g_sTag, "Found Innocent", client, client, iRagdollC[VictimName]);
+								    
+								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Innocent) - SILENT", client, sRole, iRagdollC[VictimName]);
+								    
+								    if (bSilentColor)
+								    {
+								    	SetEntityRenderColor(iEntity, 0, 255, 0, 255);
+								    }
+								    
+								    iBodyWasSilentID++;
+								}
 								addArrayTime(iItem);
 							}
 							else if (iRagdollC[VictimTeam] == TTT_TEAM_DETECTIVE)
 							{
-								LoopValidClients(j)
+								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, g_iRole[client]))
 								{
-									CPrintToChat(j, "%s %T", g_sTag, "Found Detective", j, client, iRagdollC[VictimName]);
+									LoopValidClients(j)
+									{
+										CPrintToChat(j, "%s %T", g_sTag, "Found Detective", j, client, iRagdollC[VictimName]);
+									}
+									
+									Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Detective)", client, sRole, iRagdollC[VictimName]);
+									
+									SetEntityRenderColor(iEntity, 0, 0, 255, 255);
 								}
-
-								SetEntityRenderColor(iEntity, 0, 0, 255, 255);
-								Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Detective)", client, sRole, iRagdollC[VictimName]);
+								else
+								{
+								    CPrintToChat(client, "%s %T", g_sTag, "Found Detective", client, client, iRagdollC[VictimName]);
+								    
+								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Detective) - SILENT", client, sRole, iRagdollC[VictimName])
+								    
+								    if (bSilentColor) {
+								    	SetEntityRenderColor(iEntity, 0, 0, 255, 255);
+								    }
+								    
+								    iBodyWasSilentID++;
+								}
+								
 								addArrayTime(iItem);							
 							}
 							else if (iRagdollC[VictimTeam] == TTT_TEAM_TRAITOR)
 							{
-								LoopValidClients(j)
+								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, g_iRole[client]))
 								{
-									CPrintToChat(j, "%s %T", g_sTag, "Found Traitor", j, client, iRagdollC[VictimName]);
+									LoopValidClients(j)
+									{
+										CPrintToChat(j, "%s %T", g_sTag, "Found Traitor", j, client, iRagdollC[VictimName]);
+									}
+									
+									Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Traitor)", client, sRole, iRagdollC[VictimName]);
+									
+									SetEntityRenderColor(iEntity, 255, 0, 0, 255);
 								}
-
-								SetEntityRenderColor(iEntity, 255, 0, 0, 255);
-								Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Traitor)", client, sRole, iRagdollC[VictimName]);
+								else
+								{
+								    CPrintToChat(client, "%s %T", g_sTag, "Found Traitor", client, client, iRagdollC[VictimName]);
+								    
+								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Traitor) - SILENT", client, sRole, iRagdollC[VictimName]);
+								    
+								    if (bSilentColor)
+								    {
+								    	SetEntityRenderColor(iEntity, 255, 0, 0, 255);
+								    }
+								    
+								    iBodyWasSilentID++;
+								}
 								addArrayTime(iItem);								
 							}
 
@@ -3060,6 +3114,7 @@ public int TTT_OnButtonPress(int client, int button)
 							}
 							
 							Call_PushString(iRagdollC[VictimName]);
+							Call_PushCell(iBodyWasSilentID);
 							Call_Finish();
 						}
 						g_aRagdoll.SetArray(i, iRagdollC[0]);
@@ -3069,6 +3124,10 @@ public int TTT_OnButtonPress(int client, int button)
 			}
 		}
 	}
+}
+
+public TTT_ValidSilentIDRole(int client, int role) {
+    return (TTT_GetClientRole(client) & role);
 }
 
 public int TTT_OnButtonRelease(int client, int button)

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -3132,7 +3132,7 @@ public int TTT_OnButtonPress(int client, int button)
 }
 
 public TTT_ValidSilentIDRole(int client, int role) {
-    return (TTT_GetClientRole(client) & role);
+    return (role & TTT_GetClientRole(client));
 }
 
 public int TTT_OnButtonRelease(int client, int button)

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -2989,10 +2989,7 @@ public int TTT_OnButtonPress(int client, int button)
 
 						if (!iRagdollC[Found] && IsPlayerAlive(client))
 						{
-							bool bSilentID = g_cSilentIdEnabled.BoolValue;
-							bool bInWalk = button & IN_WALK != 0;
-							bool bSilentColor = g_cSilentIdColor.BoolValue;
-							int iAllowedRolesSilentID = g_cSilentIdRoles.IntValue;
+							bool bInWalk = ((button & IN_WALK) > 0);
 							bool silentID = false;
 							
 							iRagdollC[Found] = true;
@@ -3016,7 +3013,7 @@ public int TTT_OnButtonPress(int client, int button)
 							
 							if (iRagdollC[VictimTeam] == TTT_TEAM_INNOCENT)
 							{
-								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, iAllowedRolesSilentID)))
+								if (!g_cSilentIdEnabled.BoolValue || !(bInWalk && TTT_ValidSilentIDRole(client, g_cSilentIdRoles.IntValue)))
 								{
 									LoopValidClients(j)
 									{
@@ -3033,7 +3030,7 @@ public int TTT_OnButtonPress(int client, int button)
 								    
 								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Innocent) - SILENT", client, sRole, iRagdollC[VictimName]);
 								    
-								    if (bSilentColor)
+								    if (g_cSilentIdColor.BoolValue)
 								    {
 								    	SetEntityRenderColor(iEntity, 0, 255, 0, 255);
 								    }
@@ -3044,7 +3041,7 @@ public int TTT_OnButtonPress(int client, int button)
 							}
 							else if (iRagdollC[VictimTeam] == TTT_TEAM_DETECTIVE)
 							{
-								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, iAllowedRolesSilentID)))
+								if (!g_cSilentIdEnabled.BoolValue || !(bInWalk && TTT_ValidSilentIDRole(client, g_cSilentIdRoles.IntValue)))
 								{
 									LoopValidClients(j)
 									{
@@ -3061,7 +3058,8 @@ public int TTT_OnButtonPress(int client, int button)
 								    
 								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Detective) - SILENT", client, sRole, iRagdollC[VictimName]);
 								    
-								    if (bSilentColor) {
+								    if (g_cSilentIdColor.BoolValue)
+								    {
 								    	SetEntityRenderColor(iEntity, 0, 0, 255, 255);
 								    }
 								    
@@ -3072,7 +3070,7 @@ public int TTT_OnButtonPress(int client, int button)
 							}
 							else if (iRagdollC[VictimTeam] == TTT_TEAM_TRAITOR)
 							{
-								if (!bSilentID || !(bInWalk && TTT_ValidSilentIDRole(client, iAllowedRolesSilentID)))
+								if (!g_cSilentIdEnabled.BoolValue || !(bInWalk && TTT_ValidSilentIDRole(client, g_cSilentIdRoles.IntValue)))
 								{
 									LoopValidClients(j)
 									{
@@ -3089,7 +3087,7 @@ public int TTT_OnButtonPress(int client, int button)
 								    
 								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Traitor) - SILENT", client, sRole, iRagdollC[VictimName]);
 								    
-								    if (bSilentColor)
+								    if (g_cSilentIdColor.BoolValue)
 								    {
 								    	SetEntityRenderColor(iEntity, 255, 0, 0, 255);
 								    }
@@ -3117,7 +3115,7 @@ public int TTT_OnButtonPress(int client, int button)
 							}
 							
 							Call_PushString(iRagdollC[VictimName]);
-							Call_PushCell(view_as<int>(silentID));
+							Call_PushCell(silentID);
 							Call_Finish();
 						}
 						g_aRagdoll.SetArray(i, iRagdollC[0]);

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -2094,6 +2094,7 @@ stock void ShowRules(int client, int iItem)
 	{
 		SetFailState("Can't read %s correctly! (ImportFromFile)", g_sRulesFile);
 		delete kvRules;
+		delete hFile;
 		return;
 	}
 
@@ -2101,6 +2102,7 @@ stock void ShowRules(int client, int iItem)
 	{
 		SetFailState("Can't read %s correctly! (GotoFirstSubKey)", g_sRulesFile);
 		delete kvRules;
+		delete hFile;
 		return;
 	}
 

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -3117,7 +3117,7 @@ public int TTT_OnButtonPress(int client, int button)
 							}
 							
 							Call_PushString(iRagdollC[VictimName]);
-							Call_PushCell(silentID);
+							Call_PushCell(view_as<int>(silentID));
 							Call_Finish();
 						}
 						g_aRagdoll.SetArray(i, iRagdollC[0]);

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -3030,7 +3030,7 @@ public int TTT_OnButtonPress(int client, int button)
 								}
 								else
 								{
-								    CPrintToChat(client, "%s %T", g_sTag, "Found Innocent Silent", client, client, iRagdollC[VictimName]);
+								    CPrintToChat(client, "%s %T", g_sTag, "Found Innocent Silent", client, iRagdollC[VictimName]);
 								    
 								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Innocent) - SILENT", client, sRole, iRagdollC[VictimName]);
 								    
@@ -3058,7 +3058,7 @@ public int TTT_OnButtonPress(int client, int button)
 								}
 								else
 								{
-								    CPrintToChat(client, "%s %T", g_sTag, "Found Detective Silent", client, client, iRagdollC[VictimName]);
+								    CPrintToChat(client, "%s %T", g_sTag, "Found Detective Silent", client, iRagdollC[VictimName]);
 								    
 								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Detective) - SILENT", client, sRole, iRagdollC[VictimName]);
 								    
@@ -3087,7 +3087,7 @@ public int TTT_OnButtonPress(int client, int button)
 								}
 								else
 								{
-								    CPrintToChat(client, "%s %T", g_sTag, "Found Traitor Silent", client, client, iRagdollC[VictimName]);
+								    CPrintToChat(client, "%s %T", g_sTag, "Found Traitor Silent", client, iRagdollC[VictimName]);
 								    
 								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Traitor) - SILENT", client, sRole, iRagdollC[VictimName]);
 								    

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -2992,7 +2992,7 @@ public int TTT_OnButtonPress(int client, int button)
 							bool bSilentID = g_cSilentIdEnabled.BoolValue;
 							bool bInWalk = button & IN_WALK != 0;
 							bool bSilentColor = g_cSilentIdColor.BoolValue;
-							int iBodyWasSilentID = 0;
+							bool silentID = false;
 							
 							iRagdollC[Found] = true;
 
@@ -3037,7 +3037,7 @@ public int TTT_OnButtonPress(int client, int button)
 								    	SetEntityRenderColor(iEntity, 0, 255, 0, 255);
 								    }
 								    
-								    iBodyWasSilentID++;
+								    silentID = true;
 								}
 								addArrayTime(iItem);
 							}
@@ -3064,7 +3064,7 @@ public int TTT_OnButtonPress(int client, int button)
 								    	SetEntityRenderColor(iEntity, 0, 0, 255, 255);
 								    }
 								    
-								    iBodyWasSilentID++;
+								    silentID = true;
 								}
 								
 								addArrayTime(iItem);							
@@ -3093,7 +3093,7 @@ public int TTT_OnButtonPress(int client, int button)
 								    	SetEntityRenderColor(iEntity, 255, 0, 0, 255);
 								    }
 								    
-								    iBodyWasSilentID++;
+								    silentID = true;
 								}
 								addArrayTime(iItem);								
 							}
@@ -3116,7 +3116,7 @@ public int TTT_OnButtonPress(int client, int button)
 							}
 							
 							Call_PushString(iRagdollC[VictimName]);
-							Call_PushCell(iBodyWasSilentID);
+							Call_PushCell(silentID);
 							Call_Finish();
 						}
 						g_aRagdoll.SetArray(i, iRagdollC[0]);

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -2901,13 +2901,17 @@ public Action OnPlayerRunCmd(int client, int &buttons)
 	{
 		button = (1 << i);
 
-		if ((buttons & button))
+		if ((buttons & button) || (buttons & IN_USE|IN_SPEED) == IN_USE|IN_SPEED)
 		{
 			if (!(g_iLastButtons[client] & button))
 			{
 				Call_StartForward(g_hOnButtonPress);
 				Call_PushCell(client);
-				Call_PushCell(button);
+				if ((buttons & IN_USE|IN_SPEED) == IN_USE|IN_SPEED) {
+					Call_PushCell(buttons);
+				} else {
+					Call_PushCell(button);
+				}
 				Call_Finish();
 			}
 		}
@@ -2989,7 +2993,7 @@ public int TTT_OnButtonPress(int client, int button)
 
 						if (!iRagdollC[Found] && IsPlayerAlive(client))
 						{
-							bool bInWalk = ((button & IN_WALK) > 0);
+							bool bInWalk = ((button & IN_SPEED) > 0);
 							bool silentID = false;
 							
 							iRagdollC[Found] = true;
@@ -3026,7 +3030,7 @@ public int TTT_OnButtonPress(int client, int button)
 								}
 								else
 								{
-								    CPrintToChat(client, "%s %T", g_sTag, "Found Innocent", client, client, iRagdollC[VictimName]);
+								    CPrintToChat(client, "%s %T", g_sTag, "Found Innocent Silent", client, client, iRagdollC[VictimName]);
 								    
 								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Innocent) - SILENT", client, sRole, iRagdollC[VictimName]);
 								    
@@ -3054,7 +3058,7 @@ public int TTT_OnButtonPress(int client, int button)
 								}
 								else
 								{
-								    CPrintToChat(client, "%s %T", g_sTag, "Found Detective", client, client, iRagdollC[VictimName]);
+								    CPrintToChat(client, "%s %T", g_sTag, "Found Detective Silent", client, client, iRagdollC[VictimName]);
 								    
 								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Detective) - SILENT", client, sRole, iRagdollC[VictimName]);
 								    
@@ -3083,7 +3087,7 @@ public int TTT_OnButtonPress(int client, int button)
 								}
 								else
 								{
-								    CPrintToChat(client, "%s %T", g_sTag, "Found Traitor", client, client, iRagdollC[VictimName]);
+								    CPrintToChat(client, "%s %T", g_sTag, "Found Traitor Silent", client, client, iRagdollC[VictimName]);
 								    
 								    Format(iItem, sizeof(iItem), "-> %N (%s) identified body of %s (Traitor) - SILENT", client, sRole, iRagdollC[VictimName]);
 								    

--- a/addons/sourcemod/scripting/ttt/ttt.sp
+++ b/addons/sourcemod/scripting/ttt/ttt.sp
@@ -3115,7 +3115,7 @@ public int TTT_OnButtonPress(int client, int button)
 							}
 							
 							Call_PushString(iRagdollC[VictimName]);
-							Call_PushCell(view_as<int>(silentID));
+							Call_PushCell(silentID);
 							Call_Finish();
 						}
 						g_aRagdoll.SetArray(i, iRagdollC[0]);

--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -177,7 +177,7 @@ public void OnPluginStart()
 	g_cBuyCmd = AutoExecConfig_CreateConVar("ttt_shop_buy_command", "buyitem", "The command to buy a shop item instantly");
 	g_cShowCmd = AutoExecConfig_CreateConVar("ttt_shop_show_command", "showitems", "The command to show the shortname of the shopitems (to use for the buycommand)");
 	g_cSQLCredits = AutoExecConfig_CreateConVar("ttt_sql_credits", "0", "Set 1 if you want to use credits over sql (mysql + sqlite are supported)", _, true, 0.0, true, 1.0);
-	g_cSilentIdRewards = AutoExecConfig_CreateConVar("ttt_silent_id_rewards", "1", "0 = Disabled, will not reward credits with silent id. 1 = Will reward the client with credits for inspecting the body.", _, true, 0.0, true, 1.0);
+	g_cSilentIdRewards = AutoExecConfig_CreateConVar("ttt_shop_silent_id_rewards", "1", "0 = Disabled, will not reward credits with silent id. 1 = Will reward the client with credits for inspecting the body.", _, true, 0.0, true, 1.0);
 	TTT_EndConfig();
 
 	LoadTranslations("common.phrases");
@@ -1065,7 +1065,7 @@ public void TTT_OnRoundEnd(int WinningTeam)
 	}
 }
 
-public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, book silentID = false)
+public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, bool silentID = false)
 {
 	bool bSilentRewards = g_cSilentIdRewards.BoolValue;
 	if (!silentID || (bSilentRewards && silentID))

--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -1065,10 +1065,10 @@ public void TTT_OnRoundEnd(int WinningTeam)
 	}
 }
 
-public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, book sillentID = false)
+public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, book silentID = false)
 {
 	bool bSilentRewards = g_cSilentIdRewards.BoolValue;
-	if (!sillentID || (bSilentRewards && sillentID))
+	if (!silentID || (bSilentRewards && silentID))
 	{
 		addCredits(client, g_cCreditsFoundBody.IntValue);
 	}

--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -1063,9 +1063,14 @@ public void TTT_OnRoundEnd(int WinningTeam)
 	}
 }
 
-public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer)
+public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, int isBodySilecedID = 0)
 {
-	addCredits(client, g_cCreditsFoundBody.IntValue);
+	bool bSilentID = g_cSilentIdEnabled.BoolValue;
+	bool bSilentRewards = g_cSilentIdRewards.BoolValue;
+	if (!bSilentID || (bSilentRewards && bSilentIisBodySilecedID > 0) || isBodySilecedID == 0)
+	{
+		addCredits(client, g_cCreditsFoundBody.IntValue);
+	}
 }
 
 stock void addCredits(int client, int credits, bool message = false)

--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -56,6 +56,7 @@ ConVar g_cCreditsMin = null;
 ConVar g_cCreditsMax = null;
 ConVar g_cCreditsInterval = null;
 ConVar g_cSQLCredits = null;
+ConVar g_cSilentIdRewards = null;
 
 ConVar g_cPluginTag = null;
 char g_sPluginTag[64];
@@ -176,6 +177,7 @@ public void OnPluginStart()
 	g_cBuyCmd = AutoExecConfig_CreateConVar("ttt_shop_buy_command", "buyitem", "The command to buy a shop item instantly");
 	g_cShowCmd = AutoExecConfig_CreateConVar("ttt_shop_show_command", "showitems", "The command to show the shortname of the shopitems (to use for the buycommand)");
 	g_cSQLCredits = AutoExecConfig_CreateConVar("ttt_sql_credits", "0", "Set 1 if you want to use credits over sql (mysql + sqlite are supported)", _, true, 0.0, true, 1.0);
+	g_cSilentIdRewards = AutoExecConfig_CreateConVar("ttt_silent_id_rewards", "1", "0 = Disabled, will not reward credits with silent id. 1 = Will reward the client with credits for inspecting the body.", _, true, 0.0, true, 1.0);
 	TTT_EndConfig();
 
 	LoadTranslations("common.phrases");
@@ -1063,11 +1065,10 @@ public void TTT_OnRoundEnd(int WinningTeam)
 	}
 }
 
-public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, int isBodySilecedID = 0)
+public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, book sillentID = false)
 {
-	bool bSilentID = g_cSilentIdEnabled.BoolValue;
 	bool bSilentRewards = g_cSilentIdRewards.BoolValue;
-	if (!bSilentID || (bSilentRewards && bSilentIisBodySilecedID > 0) || isBodySilecedID == 0)
+	if (!sillentID || (bSilentRewards && sillentID))
 	{
 		addCredits(client, g_cCreditsFoundBody.IntValue);
 	}

--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -1067,8 +1067,7 @@ public void TTT_OnRoundEnd(int WinningTeam)
 
 public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, bool silentID)
 {
-	bool bSilentRewards = g_cSilentIdRewards.BoolValue;
-	if (!silentID || (bSilentRewards && silentID))
+	if (!silentID || (g_cSilentIdRewards.BoolValue && silentID))
 	{
 		addCredits(client, g_cCreditsFoundBody.IntValue);
 	}

--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -1065,7 +1065,7 @@ public void TTT_OnRoundEnd(int WinningTeam)
 	}
 }
 
-public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, bool silentID = false)
+public void TTT_OnBodyFound(int client, int victim, const char[] deadPlayer, bool silentID)
 {
 	bool bSilentRewards = g_cSilentIdRewards.BoolValue;
 	if (!silentID || (bSilentRewards && silentID))

--- a/addons/sourcemod/translations/ttt.phrases.txt
+++ b/addons/sourcemod/translations/ttt.phrases.txt
@@ -1007,18 +1007,18 @@
 	"Found Innocent Silent"
 	{
 		"#format"	"{1:s}"
-		"en"		"{lightgreen}You silently found the body of {green}{2}. {lightgreen}It was a {green}INNOCENT!"
+		"en"		"{lightgreen}You silently found the body of {green}{1}. {lightgreen}It was a {green}INNOCENT!"
 	}
 
 	"Found Detective Silent"
 	{
 		"#format"	"{1:s}"
-		"en"		"{lightgreen}You silently found the body of {darkblue}{2}. {lightgreen}It was a {darkblue}DETECTIVE!"
+		"en"		"{lightgreen}You silently found the body of {darkblue}{1}. {lightgreen}It was a {darkblue}DETECTIVE!"
 	}
 
 	"Found Traitor Silent"
 	{
 		"#format"	"{1:s}"
-		"en"		"{lightgreen}You silently found the body of {darkred}{2}. {lightgreen}It was a {darkred}Traitor!"
+		"en"		"{lightgreen}You silently found the body of {darkred}{1}. {lightgreen}It was a {darkred}Traitor!"
 	}
 }

--- a/addons/sourcemod/translations/ttt.phrases.txt
+++ b/addons/sourcemod/translations/ttt.phrases.txt
@@ -1004,5 +1004,21 @@
 		"#format"	"{1:s}"
 		"en"		"Can't find '{1}' as valid shop item"
 	}
+	"Found Innocent Silent"
+	{
+		"#format"	"{1:s}"
+		"en"		"{lightgreen}You silently found the body of {green}{2}. {lightgreen}It was a {green}INNOCENT!"
+	}
 
+	"Found Detective Silent"
+	{
+		"#format"	"{1:s}"
+		"en"		"{lightgreen}You silently found the body of {darkblue}{2}. {lightgreen}It was a {darkblue}DETECTIVE!"
+	}
+
+	"Found Traitor Silent"
+	{
+		"#format"	"{1:s}"
+		"en"		"{lightgreen}You silently found the body of {darkred}{2}. {lightgreen}It was a {darkred}Traitor!"
+	}
 }


### PR DESCRIPTION
This is the Silent ID feature.

New CVARs:
**"ttt_silent_id"** "0"- Enable/Disable Silent ID feature
**"ttt_silent_id_color"** "1"- Enable/Disable coloring the body when Silent ID.
**"ttt_silent_id_roles"** "14"- Roles allowed to silent ID. See [Masks](https://github.com/Bara/TroubleinTerroristTown/wiki/CVAR-Masks) for more detailed information.
**"ttt_silent_id_rewards"** "1"- Should the player be rewarded when using Silent ID?

This feature allow players to inspect a body without notifying others. By holding Walk (+speed) + Use (+use) on a body.

More information: https://skynetgaming.net/forums/topic/10391-request-silent-id-bodies/