### PR TITLE
Log Round Shop Purchases

### DIFF
--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -741,19 +741,8 @@ bool ClientBuyItem(int client, char[] item, bool menu, bool free = false)
                             Format(sClientID, sizeof(sClientID), " (%s)", sClientID);
                         }
                     }
-
-                    if (TTT_GetClientRole(client) == TTT_TEAM_DETECTIVE)
-                    {
-                        TTT_LogString("-> [%N%s (%s) purchased an item from the shop: %s]", client, sClientID, sRole, temp_item[Long]);
-                    }
-                    else if (TTT_GetClientRole(client) == TTT_TEAM_TRAITOR)
-                    {
-                        TTT_LogString("-> [%N%s (%s) purchased an item from the shop: %s]", client, sClientID, sRole, temp_item[Long]);
-                    }
-                    else if (TTT_GetClientRole(client) == TTT_TEAM_INNOCENT)
-                    {
-                        TTT_LogString("-> [%N%s (%s) purchased an item from the shop: %s]", client, sClientID, sRole, temp_item[Long]);
-                    }
+                    
+                    TTT_LogString("-> [%N%s (%s) purchased an item from the shop: %s]", client, sClientID, sRole, temp_item[Long]);
                     
                     return true;
                 }

--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -715,17 +715,41 @@ bool ClientBuyItem(int client, char[] item, bool menu, bool free = false)
                         CPrintToChat(client, "%s %T", g_sPluginTag, "Item bought! (NEW)", client, g_iCredits[client], temp_item[Long], price);
                     }
 
+                    char sClientID[32], sRole[ROLE_LENGTH];
+                    TTT_GetRoleNameByID(TTT_GetClientRole(client), sRole, sizeof(sRole));
+                    
+                    if (cAddLogs.BoolValue)
+                    {
+                        if (cLogFormat.IntValue == 1)
+                        {
+                            GetClientAuthId(client, AuthId_Steam2, sClientID, sizeof(sClientID));
+                        }
+                        else if (cLogFormat.IntValue == 2)
+                        {
+                            GetClientAuthId(client, AuthId_Steam3, sClientID, sizeof(sClientID));
+                        }
+                        else if (cLogFormat.IntValue == 3)
+                        {
+                            GetClientAuthId(client, AuthId_SteamID64, sClientID, sizeof(sClientID));
+                        }
+                        
+                        if (strlen(sClientID) > 2)
+                        {
+                            Format(sClientID, sizeof(sClientID), " (%s)", sClientID);
+                        }
+                    }
+
                     if (TTT_GetClientRole(client) == TTT_TEAM_DETECTIVE)
                     {
-                        TTT_LogString("-> [%N%s (Detective) purchased an item from the shop: %s]", client, sClientID, temp_item[Long]);
+                        TTT_LogString("-> [%N%s (%s) purchased an item from the shop: %s]", client, sClientID, sRole, temp_item[Long]);
                     }
                     else if (TTT_GetClientRole(client) == TTT_TEAM_TRAITOR)
                     {
-                        TTT_LogString("-> [%N%s (Traitor) purchased an item from the shop: %s]", client, sClientID, temp_item[Long]);
+                        TTT_LogString("-> [%N%s (%s) purchased an item from the shop: %s]", client, sClientID, sRole, temp_item[Long]);
                     }
                     else if (TTT_GetClientRole(client) == TTT_TEAM_INNOCENT)
                     {
-                        TTT_LogString("-> [%N%s (Innocent) purchased an item from the shop: %s]", client, sClientID, temp_item[Long]);
+                        TTT_LogString("-> [%N%s (%s) purchased an item from the shop: %s]", client, sClientID, sRole, temp_item[Long]);
                     }
                     
                     return true;

--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -717,7 +717,10 @@ bool ClientBuyItem(int client, char[] item, bool menu, bool free = false)
 
                     char sClientID[32], sRole[ROLE_LENGTH];
                     TTT_GetRoleNameByID(TTT_GetClientRole(client), sRole, sizeof(sRole));
-                    
+
+                    ConVar cAddLogs = FindConVar("ttt_steamid_add_to_logs");
+                    ConVar cLogFormat = FindConVar("ttt_steamid_log_format");
+
                     if (cAddLogs.BoolValue)
                     {
                         if (cLogFormat.IntValue == 1)

--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -714,6 +714,19 @@ bool ClientBuyItem(int client, char[] item, bool menu, bool free = false)
                     {
                         CPrintToChat(client, "%s %T", g_sPluginTag, "Item bought! (NEW)", client, g_iCredits[client], temp_item[Long], price);
                     }
+
+                    if (TTT_GetClientRole(client) == TTT_TEAM_DETECTIVE)
+                    {
+                        TTT_LogString("-> [%N%s (Detective) purchased an item from the shop: %s]", client, sClientID, temp_item[Long]);
+                    }
+                    else if (TTT_GetClientRole(client) == TTT_TEAM_TRAITOR)
+                    {
+                        TTT_LogString("-> [%N%s (Traitor) purchased an item from the shop: %s]", client, sClientID, temp_item[Long]);
+                    }
+                    else if (TTT_GetClientRole(client) == TTT_TEAM_INNOCENT)
+                    {
+                        TTT_LogString("-> [%N%s (Innocent) purchased an item from the shop: %s]", client, sClientID, temp_item[Long]);
+                    }
                     
                     return true;
                 }

--- a/addons/sourcemod/scripting/ttt/ttt_shop.sp
+++ b/addons/sourcemod/scripting/ttt/ttt_shop.sp
@@ -63,6 +63,8 @@ ConVar g_cSetCreditsFlag = null;
 ConVar g_cResetItemsFlag = null;
 ConVar g_cListItemsFlag = null;
 ConVar g_cShopCMDs = null;
+ConVar g_cAddLogs = null;
+ConVar g_cLogFormat = null;
 
 ConVar g_cPluginTag = null;
 char g_sPluginTag[64];
@@ -215,7 +217,10 @@ public void OnConfigsExecuted()
     g_cPluginTag = FindConVar("ttt_plugin_tag");
     g_cPluginTag.AddChangeHook(OnConVarChanged);
     g_cPluginTag.GetString(g_sPluginTag, sizeof(g_sPluginTag));
-    
+
+    g_cAddLogs = FindConVar("ttt_steamid_add_to_logs");
+    g_cLogFormat = FindConVar("ttt_steamid_log_format");
+
     char sBuffer[32];
     g_cCredits.GetString(sBuffer, sizeof(sBuffer));
     Format(sBuffer, sizeof(sBuffer), "sm_%s", sBuffer);
@@ -718,20 +723,17 @@ bool ClientBuyItem(int client, char[] item, bool menu, bool free = false)
                     char sClientID[32], sRole[ROLE_LENGTH];
                     TTT_GetRoleNameByID(TTT_GetClientRole(client), sRole, sizeof(sRole));
 
-                    ConVar cAddLogs = FindConVar("ttt_steamid_add_to_logs");
-                    ConVar cLogFormat = FindConVar("ttt_steamid_log_format");
-
-                    if (cAddLogs.BoolValue)
+                    if (g_cAddLogs != null && g_cAddLogs.BoolValue)
                     {
-                        if (cLogFormat.IntValue == 1)
+                        if (g_cLogFormat.IntValue == 1)
                         {
                             GetClientAuthId(client, AuthId_Steam2, sClientID, sizeof(sClientID));
                         }
-                        else if (cLogFormat.IntValue == 2)
+                        else if (g_cLogFormat.IntValue == 2)
                         {
                             GetClientAuthId(client, AuthId_Steam3, sClientID, sizeof(sClientID));
                         }
-                        else if (cLogFormat.IntValue == 3)
+                        else if (g_cLogFormat.IntValue == 3)
                         {
                             GetClientAuthId(client, AuthId_SteamID64, sClientID, sizeof(sClientID));
                         }


### PR DESCRIPTION
This merge request updates the ttt_shop plugin by adding the functionality necessary to record player item purchases to the round logs. It was originally a request of EdgeGamers CSLE and the original message I received will be posted below:

> When a Traitor purchases a weapon, add it to the sm_logs - this is because sometimes a traitor is killed when they are caught purchasing a Traitor-Only weapon, but admins can't find out if that was the case.

The ttt_shop plugin will still compile without any errors nor warnings.